### PR TITLE
fix: indexing of groups and pages when calling games from the tutorial

### DIFF
--- a/main-page/src/utils/setTextBookGameRoutes.tsx
+++ b/main-page/src/utils/setTextBookGameRoutes.tsx
@@ -8,13 +8,15 @@ const setTextBookGameRoutes = (gameName: string) => {
   const routes = []
 
   for (let i = 1; i <= TextBookConstants.MAX_GROUPS; i++) {
-    for (let j = 1; j < TextBookConstants.MAX_PAGES; j++) {
+    for (let j = 1; j <= TextBookConstants.MAX_PAGES; j++) {
       if (gameName === 'audioChallenge') {
         routes.push(
           <Route
             key={`gameName${j}`}
             path={`${gameName}/${i}/${j}`}
-            element={<AudioChallenge group={i} page={j} fromPage={true} />}
+            element={
+              <AudioChallenge group={i - 1} page={j - 1} fromPage={true} />
+            }
           />
         )
       }
@@ -24,7 +26,7 @@ const setTextBookGameRoutes = (gameName: string) => {
           <Route
             key={`gameName${j}`}
             path={`${gameName}/${i}/${j}`}
-            element={<Sprint group={i} page={j} fromPage={true} />}
+            element={<Sprint group={i - 1} page={j - 1} fromPage={true} />}
           />
         )
       }


### PR DESCRIPTION
[Task: "RS Lang"](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/stage-2/rs-lang/rslang.md)

- [x] change the logic of path definition in the textbook


